### PR TITLE
fix note holds animations on player

### DIFF
--- a/scenes/game/songs/basic_song.gd
+++ b/scenes/game/songs/basic_song.gd
@@ -67,8 +67,6 @@ func note_holding(time, lane, length, note_type, strum_manager):
 	if length <= 0:
 		get_tree().call_group(group, &"set_holding", false)
 	
-	get_tree().call_group(group, &"play_animation", get_direction(lane % 4))
-	
 	playstate_host.note_holding(time, lane, length, note_type, strum_manager)
 
 

--- a/scenes/game/strumlines/strum.gd
+++ b/scenes/game/strumlines/strum.gd
@@ -96,7 +96,7 @@ func _process(delta):
 						
 						note.get_node("Note").visible = false
 						
-						emit_signal("note_holding", temp - note.length, self.get_name(), note.note_type)
+						emit_signal("note_holding", temp - note.length, self.get_name(), note.length, note.note_type)
 						state = STATE.GLOW
 					
 					else:
@@ -170,7 +170,7 @@ func _process(delta):
 							note.length = ((note.time - offset) + (note.start_length * GameManager.seconds_per_beat)) - GameManager.song_position
 							note.length /= GameManager.seconds_per_beat
 							note.get_node("Note").visible = false
-							emit_signal("note_holding", temp - note.length, self.get_name(), note.note_type)
+							emit_signal("note_holding", temp - note.length, self.get_name(), note.length, note.note_type)
 							
 							if !pressing:
 								hold_cover_sprite.play_animation("cover " + strum_name + " start")
@@ -180,7 +180,7 @@ func _process(delta):
 							
 							if note.length <= 0:
 								pressing = false
-								emit_signal("note_holding", temp - note.length, self.get_name(), note.note_type)
+								emit_signal("note_holding", temp - note.length, self.get_name(), note.length, note.note_type)
 							
 								if can_splash:
 									hold_cover_sprite.play_animation("cover " + strum_name + " end")


### PR DESCRIPTION
for some reason hold notes dont actually hold the player animation, and just go back to idle whenever the sing animation is done instead of holding the frame