### PR TITLE
fix hold note bug (read desc)

### DIFF
--- a/scenes/game/strumlines/strum.gd
+++ b/scenes/game/strumlines/strum.gd
@@ -195,19 +195,20 @@ func _process(delta):
 	
 	elif Input.is_action_just_released(input):
 		if can_press:
-			state = STATE.IDLE
-			
-			if hold_cover_sprite.animation != "cover " + strum_name + " end":
-				hold_cover_sprite.visible = false
-			
 			if pressing:
+				pressing = false
+				reset_timer = GameManager.seconds_per_beat / 4
+				if hold_cover_sprite.animation != "cover " + strum_name + " end":
+						hold_cover_sprite.visible = false
 				if note_list.size() > 0:
 					var note = note_list[0]
 					# Checks if you were holding a note before releasing
-					if note.can_press:
-						if note.length > 0:
-							note.start_length = note.length
-	
+					if note.can_press and note.length > 0:
+						note.start_length = note.length
+						emit_signal("note_holding", 0.0, self.get_name(), 0.0, note.note_type)
+			else:
+				state = STATE.IDLE
+				
 	if (reset_timer > 0):
 		reset_timer -= delta
 		if reset_timer <= 0:


### PR DESCRIPTION
basically if you were holding a note and you let go mid press it would bug out the strums and the player wouldnt return back to its idle animation, causing holding AND can_idle to be false until hitting the next note, so missing mid hold note if its the last note of ur section would get you stuck in that miss animation and the strum wouldnt play its ghost tap anim until you hit another note

i love critterclash!