### PR TITLE
Fix warning spam for missing save file

### DIFF
--- a/scenes/global/save_manager.gd
+++ b/scenes/global/save_manager.gd
@@ -14,7 +14,7 @@ func flush():
 
 func _load():
 	if !FileAccess.file_exists(LOAD_PATH):
-		printerr("(SaveManager) Save File does not exist. Creating a new save")
+		printerr("(SaveManager) Save File does not exist. Creating a new Save File.")
 		flush()
 		return
 	

--- a/scenes/global/save_manager.gd
+++ b/scenes/global/save_manager.gd
@@ -14,7 +14,8 @@ func flush():
 
 func _load():
 	if !FileAccess.file_exists(LOAD_PATH):
-		printerr("(SaveManager) Save File does not exist")
+		printerr("(SaveManager) Save File does not exist. Creating a new save")
+		flush()
 		return
 	
 	instance = load(LOAD_PATH)


### PR DESCRIPTION
If you do not have a existing score save file and have yet to beat a song, the console will keep printing warning each boot up until you beat a song.

This change creates a new score save file if there isn't one