### PR TITLE
Note Priority and Strum Cleanup

### DIFF
--- a/noah/game/basic_song.gd
+++ b/noah/game/basic_song.gd
@@ -167,19 +167,37 @@ func _on_new_event(time: float, event_name: String, event_parameters: Array):
 
 func _on_combo_break():
 	SoundManager.miss.play()
-	show_combo("miss", 0)
+	show_combo(GameManager.HIT_RATING.MISS, 0)
 
 
-func show_combo(rating: String, _combo: int):
+func show_combo(rating: GameManager.HIT_RATING, _combo: int):
 	if playstate:
-		if rating != "miss":
+		var hit_rating: String
+		
+		match rating:
+			GameManager.HIT_RATING.SICK:
+				hit_rating = "sick"
+			
+			GameManager.HIT_RATING.GOOD:
+				hit_rating = "good"
+			
+			GameManager.HIT_RATING.BAD:
+				hit_rating = "bad"
+			
+			GameManager.HIT_RATING.SHIT:
+				hit_rating = "shit"
+			
+			_:
+				hit_rating = "miss"
+		
+		if rating != GameManager.HIT_RATING.MISS:
 			if playstate.song_stats.sicks == playstate.song_stats.total_notes:
-				rating = "fc_" + rating
+				hit_rating = str("fc_", hit_rating)
 		
 		var rating_instance = rating_node.instantiate()
 		
 		rating_instance.ui_skin = playstate.ui_skin
-		rating_instance.rating = rating
+		rating_instance.rating = hit_rating
 		
 		var combo_numbers_manager_instance = combo_numbers_manager_node.instantiate()
 		

--- a/noah/game/basic_song.gd
+++ b/noah/game/basic_song.gd
@@ -167,30 +167,30 @@ func _on_new_event(time: float, event_name: String, event_parameters: Array):
 
 func _on_combo_break():
 	SoundManager.miss.play()
-	show_combo(GameManager.HIT_RATING.MISS, 0)
+	show_combo(NoahStats.HIT_RATING.MISS, 0)
 
 
-func show_combo(rating: GameManager.HIT_RATING, _combo: int):
+func show_combo(rating: NoahStats.HIT_RATING, _combo: int):
 	if playstate:
 		var hit_rating: String
 		
 		match rating:
-			GameManager.HIT_RATING.SICK:
+			NoahStats.HIT_RATING.SICK:
 				hit_rating = "sick"
 			
-			GameManager.HIT_RATING.GOOD:
+			NoahStats.HIT_RATING.GOOD:
 				hit_rating = "good"
 			
-			GameManager.HIT_RATING.BAD:
+			NoahStats.HIT_RATING.BAD:
 				hit_rating = "bad"
 			
-			GameManager.HIT_RATING.SHIT:
+			NoahStats.HIT_RATING.SHIT:
 				hit_rating = "shit"
 			
 			_:
 				hit_rating = "miss"
 		
-		if rating != GameManager.HIT_RATING.MISS:
+		if rating != NoahStats.HIT_RATING.MISS:
 			if playstate.song_stats.sicks == playstate.song_stats.total_notes:
 				hit_rating = str("fc_", hit_rating)
 		

--- a/noah/game/note/basic_note.gd
+++ b/noah/game/note/basic_note.gd
@@ -108,3 +108,8 @@ func load_basic_type():
 			no_animation = true
 		"alt_prefix":
 			anim_prefix = 'alt_'
+
+
+func apply_miss_effect():
+	modulate *= 2
+	modulate.a = min(modulate.a / 2, 0.5)

--- a/noah/game/note/basic_note.gd
+++ b/noah/game/note/basic_note.gd
@@ -24,7 +24,6 @@ const DEFAULT_ANIMATION_DATA: Dictionary[StringName, StringName] = {
 @onready var end = null
 
 var start_length: float = 0.0
-var can_press: bool = false
 var time_difference: float = INF
 var on_screen: bool = false
 var holding: bool = false

--- a/noah/game/playstate.gd
+++ b/noah/game/playstate.gd
@@ -172,7 +172,6 @@ func _ready() -> void:
 	Signals.play_setup_finished.emit()
 
 func _process(delta) -> void:
-	
 	if health <= health_min and !died:
 		GameManager.deaths += 1
 		

--- a/noah/game/playstate.gd
+++ b/noah/game/playstate.gd
@@ -456,23 +456,23 @@ func note_hit(note: Note, lane: int, hit_time: float, strum_manager: StrumManage
 		
 		song_stats.total_notes += 1
 		match NoahStats.get_hit_rating(hit_time):
-			"sick":
+			GameManager.HIT_RATING.SICK:
 				song_stats.sicks += 1
 				health += Constants.HEALTH_GAIN * note.health_mult
 				strum_manager.create_splash(lane, note.splash_animation)
 				if note.scoreable:
 					add_combo()
-			"good":
+			GameManager.HIT_RATING.GOOD:
 				song_stats.goods += 1
 				health += Constants.HEALTH_GAIN * note.health_mult
 				if note.scoreable:
 					add_combo()
-			"bad":
+			GameManager.HIT_RATING.BAD:
 				song_stats.bads += 1
 				health -= Constants.BAD_HIT_HEALTH_PENALTY * note.health_mult
 				if note.scoreable:
 					reset_combo()
-			"shit":
+			GameManager.HIT_RATING.SHIT:
 				song_stats.shits += 1
 				health -= Constants.BAD_HIT_HEALTH_PENALTY * note.health_mult
 				if note.scoreable:

--- a/noah/game/playstate.gd
+++ b/noah/game/playstate.gd
@@ -456,23 +456,23 @@ func note_hit(note: Note, lane: int, hit_time: float, strum_manager: StrumManage
 		
 		song_stats.total_notes += 1
 		match NoahStats.get_hit_rating(hit_time):
-			GameManager.HIT_RATING.SICK:
+			NoahStats.HIT_RATING.SICK:
 				song_stats.sicks += 1
 				health += Constants.HEALTH_GAIN * note.health_mult
 				strum_manager.create_splash(lane, note.splash_animation)
 				if note.scoreable:
 					add_combo()
-			GameManager.HIT_RATING.GOOD:
+			NoahStats.HIT_RATING.GOOD:
 				song_stats.goods += 1
 				health += Constants.HEALTH_GAIN * note.health_mult
 				if note.scoreable:
 					add_combo()
-			GameManager.HIT_RATING.BAD:
+			NoahStats.HIT_RATING.BAD:
 				song_stats.bads += 1
 				health -= Constants.BAD_HIT_HEALTH_PENALTY * note.health_mult
 				if note.scoreable:
 					reset_combo()
-			GameManager.HIT_RATING.SHIT:
+			NoahStats.HIT_RATING.SHIT:
 				song_stats.shits += 1
 				health -= Constants.BAD_HIT_HEALTH_PENALTY * note.health_mult
 				if note.scoreable:

--- a/noah/game/strumlines/strum.gd
+++ b/noah/game/strumlines/strum.gd
@@ -35,7 +35,7 @@ var song_speed: float = 1.0
 var offset: float = 0.0
 var note_list: Array[BasicNote] = []
 var pressing: bool = false
-var target_note = null
+var target_note: BasicNote = null
 var state: STATE = STATE.IDLE
 var lane: int = -1
 
@@ -73,18 +73,22 @@ func _process(delta) -> void:
 			if target_note:
 				state = STATE.GLOW
 				coyote_timer = 0
-				target_note.hit = true
 				var hit_time: float = (target_note.time - offset) - (GameManager.song_position)
 				Signals.play_note_hit.emit(target_note, lane, hit_time, get_parent())
 				
 				if target_note.length <= 0:
-					note_list.erase(target_note)
-					target_note.queue_free()
+					target_note.hit = true
 					pressing = false
+					var hit_rating: GameManager.HIT_RATING = NoahStats.get_hit_rating(hit_time)
+					if hit_rating == GameManager.HIT_RATING.BAD or hit_rating == GameManager.HIT_RATING.SHIT:
+						target_note.hit = true
+						target_note.apply_miss_effect()
+					else:
+						note_list.erase(target_note)
+						target_note.queue_free()
 				else:
-					if !pressing:
-						hold_cover_sprite.play_animation(&"start_" + strum_name + &"_cover")
-						hold_cover_sprite.visible = true
+					hold_cover_sprite.play_animation(&"start_" + strum_name + &"_cover")
+					hold_cover_sprite.visible = true
 					
 					pressing = true
 					target_note.holding = true
@@ -93,28 +97,30 @@ func _process(delta) -> void:
 					Signals.play_note_miss.emit(null, lane, get_parent())
 	
 	if Input.is_action_pressed(input):
-		if can_press and pressing:
+		if can_press:
 			if target_note:
-				if target_note.length > 0:
-					state = STATE.GLOW
-					target_note.position.y = 0
-					var temp = target_note.length
-					var spb: float = get_relative_seconds_per_beat(target_note)
-					target_note.length = ((target_note.time - offset) + (target_note.start_length * spb)) - GameManager.song_position
-					target_note.length /= spb
-					target_note.note.visible = false
-					Signals.play_note_holding.emit(target_note, lane, temp - max(0, target_note.length), get_parent())
-					
-					if target_note.length <= 0:
-						pressing = false
-						if can_splash:
-							hold_cover_sprite.play_animation(&"end_" + strum_name + &"_cover")
-						else:
-							hold_cover_sprite.visible = false
+				if pressing:
+					if target_note.length > 0:
+						state = STATE.GLOW
+						target_note.position.y = 0
+						var temp = target_note.length
+						var spb: float = get_relative_seconds_per_beat(target_note)
+						target_note.length = ((target_note.time - offset) + (target_note.start_length * spb)) - GameManager.song_position
+						target_note.length /= spb
+						target_note.note.visible = false
+						Signals.play_note_holding.emit(target_note, lane, temp - max(0, target_note.length), get_parent())
 						
-						note_list.erase(target_note)
-						target_note.queue_free()
+						if target_note.length <= 0:
+							pressing = false
+							if can_splash:
+								hold_cover_sprite.play_animation(&"end_" + strum_name + &"_cover")
+							else:
+								hold_cover_sprite.visible = false
+							
+							note_list.erase(target_note)
+							target_note.queue_free()
 			elif state != STATE.GLOW:
+				print("ok")
 				state = STATE.PRESSED
 	
 	if Input.is_action_just_released(input):
@@ -129,10 +135,9 @@ func _process(delta) -> void:
 	if coyote_timer > 0:
 		coyote_timer -= delta
 		if coyote_timer <= 0:
-			var note = get_prioritized_note(GameManager.SHIT_RATING_WINDOW)
-			if note:
-				note.time -= note.length * GameManager.conductor.seconds_per_beat
-				note.time -= GameManager.BAD_RATING_WINDOW
+			Signals.play_note_miss.emit(target_note, lane, get_parent())
+			target_note.hit = true
+			target_note.apply_miss_effect()
 	
 	if state == STATE.IDLE:
 		sprite.play_animation(strum_name + &"_strum")
@@ -164,7 +169,7 @@ func set_skin(new_skin: NoteSkin):
 
 
 func create_note(time: float, length: float, note_type: String, _tempo: float):
-	var note_instance;
+	var note_instance: BasicNote
 	if node_type == 0:
 		note_instance = NOTE_PRELOAD.instantiate()
 	else:
@@ -174,7 +179,8 @@ func create_note(time: float, length: float, note_type: String, _tempo: float):
 	note_instance.length = length
 	note_instance.start_length = length
 	note_instance.note_type = note_type
-	note_instance.position.y = 1000
+	note_instance.position.y = PIXELS_PER_SECOND * 10
+	note_instance.scroll_speed = scroll_speed
 	note_instance.scroll = scroll
 	note_instance.tempo = _tempo
 	
@@ -232,7 +238,7 @@ func release_note():
 			var note = get_prioritized_note(GameManager.SHIT_RATING_WINDOW)
 			if note:
 				# Checks if you were holding a note before releasing
-				if note.can_press and note.length > 0:
+				if target_note and note.length > 0:
 					note.holding = false
 					coyote_timer = GameManager.HOLD_NOTE_LENIENCY
 					note.time = GameManager.song_position
@@ -245,7 +251,7 @@ func get_relative_seconds_per_beat(note: Note) -> float:
 	return (GameManager.conductor.tempo / note.tempo) * GameManager.conductor.seconds_per_beat
 
 ## Returns the highest prioritized note within the hit window.
-func get_prioritized_note(hit_window: float) -> Variant:
+func get_prioritized_note(hit_window: float) -> BasicNote:
 	if note_list.is_empty():
 		return null
 	

--- a/noah/game/strumlines/strum.gd
+++ b/noah/game/strumlines/strum.gd
@@ -19,7 +19,7 @@ var SPLASH_PRELOAD = preload("uid://c23s1pbajtga2")
 @export var auto_play: bool  = false
 @export var can_splash: bool  = false
 @export var enemy_slot: bool = false
-## Note types that autoplay wont press
+## Note types that will be skipped over in note prioritization.
 @export var ignored_note_types: Array = []
 @export_enum("NORMAL", "MODCHART") var node_type: int
 
@@ -35,7 +35,7 @@ var song_speed: float = 1.0
 var offset: float = 0.0
 var note_list: Array[BasicNote] = []
 var pressing: bool = false
-var previous_note = null
+var target_note = null
 var state: STATE = STATE.IDLE
 var lane: int = -1
 
@@ -62,18 +62,17 @@ func _process(delta) -> void:
 		if time_difference <= GameManager.SHIT_RATING_WINDOW:
 			note.can_press = true
 			
-			if !enemy_slot:
-				if note == note_list.front():
-					if SettingsManager.get_value(SettingsManager.SEC_PREFERENCES, "glow_notes"):
-						note.modulate = Color(1.5, 1.5, 1.5)
+			#if !enemy_slot:
+				#if note == get_prioritized_note(GameManager.SHIT_RATING_WINDOW):
+					#if SettingsManager.get_value(SettingsManager.SEC_PREFERENCES, "glow_notes") and !note.bad:
+						#note.modulate = Color(1.5, 1.5, 1.5)
 		
 		if auto_play:
 			if time_difference <= delta:
 				if !ignored_note_types.has(note.note_type):
-					if note != previous_note:
+					if note != target_note:
 						note.hit = true
 						Signals.play_note_hit.emit(note, lane, 0, get_parent())
-						previous_note = note
 					
 					if note.length > 0:
 						note.holding = true
@@ -105,18 +104,16 @@ func _process(delta) -> void:
 		
 		var relative_time: float = time_difference - offset + (note.start_length * GameManager.conductor.seconds_per_beat)
 		var hit_window: float = GameManager.SHIT_RATING_WINDOW
-		if ignored_note_types.has(note.note_type):
-			# This is for stuff like mine's so they have a smaller hit qindow
-			hit_window = GameManager.GOOD_RATING_WINDOW
 		
 		if relative_time <= -hit_window and coyote_timer <= 0:
 			note_list.erase(note)
 			Signals.play_note_miss.emit(note, lane, get_parent())
 			note.queue_free()
+		
 	# Inputs
 	if Input.is_action_just_pressed(input):
 		if can_press:
-			var note = note_list.front()
+			var note = get_prioritized_note(GameManager.SHIT_RATING_WINDOW)
 			if note:
 				if note.can_press:
 					if note.length <= 0:
@@ -131,7 +128,7 @@ func _process(delta) -> void:
 						Signals.play_note_hit.emit(note, lane, time_difference, get_parent())
 					else:
 						var time_difference = (note.time - offset) - (GameManager.song_position)
-						if note != previous_note:
+						if note != target_note:
 							note.hit = true
 							Signals.play_note_hit.emit(note, lane, time_difference, get_parent())
 						
@@ -143,7 +140,7 @@ func _process(delta) -> void:
 						
 						pressing = true
 						note.holding = true
-						previous_note = note
+						target_note = note
 				else:
 					if !SettingsManager.get_value(SettingsManager.SEC_GAMEPLAY, "ghost_tapping"):
 						Signals.play_note_miss.emit(null, lane, get_parent())
@@ -154,7 +151,7 @@ func _process(delta) -> void:
 	if Input.is_action_pressed(input):
 		if can_press:
 			if pressing:
-				var note = note_list.front()
+				var note = get_prioritized_note(GameManager.SHIT_RATING_WINDOW)
 				if note:
 					if note.can_press:
 						if note.length > 0:
@@ -197,7 +194,7 @@ func _process(delta) -> void:
 	if coyote_timer > 0:
 		coyote_timer -= delta
 		if coyote_timer <= 0:
-			var note = note_list.front()
+			var note = get_prioritized_note(GameManager.SHIT_RATING_WINDOW)
 			if note:
 				note.time -= note.length * GameManager.conductor.seconds_per_beat
 				note.time -= GameManager.BAD_RATING_WINDOW
@@ -297,7 +294,7 @@ func release_note():
 			if hold_cover_sprite.animation != "cover " + strum_name + " end":
 				hold_cover_sprite.visible = false
 			
-			var note = note_list.front()
+			var note = get_prioritized_note(GameManager.SHIT_RATING_WINDOW)
 			if note:
 				# Checks if you were holding a note before releasing
 				if note.can_press and note.length > 0:
@@ -311,3 +308,23 @@ func release_note():
 ## Returns the seconds per beat relative to the given note.
 func get_relative_seconds_per_beat(note: Note) -> float:
 	return (GameManager.conductor.tempo / note.tempo) * GameManager.conductor.seconds_per_beat
+
+## Returns the highest prioritized note within the hit window.
+func get_prioritized_note(hit_window: float) -> Variant:
+	if note_list.is_empty():
+		return null
+	
+	var target = null
+	for note in note_list:
+		if note.hit:
+			continue
+		
+		target = note
+		
+		if !ignored_note_types.has(note.note_type):
+			return note
+		
+		if note.time_difference > hit_window:
+			break
+	
+	return target

--- a/noah/game/strumlines/strum.gd
+++ b/noah/game/strumlines/strum.gd
@@ -29,8 +29,8 @@ enum STATE {
 	GLOW,
 }
 
-var scroll_speed: float = 1.0
-var scroll: float = 1.0
+var scroll_speed: float = 1.0: set = set_scroll_speed
+var scroll: float = 1.0: set = set_scroll
 var song_speed: float = 1.0
 var offset: float = 0.0
 var note_list: Array[BasicNote] = []
@@ -53,132 +53,67 @@ func _ready() -> void:
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta) -> void:
-	for note in note_list:
-		var time_difference: float = note.time_difference
-		
-		note.scroll_speed = scroll_speed
-		note.scroll = scroll
-		
-		if time_difference <= GameManager.SHIT_RATING_WINDOW:
-			note.can_press = true
-			
-			#if !enemy_slot:
-				#if note == get_prioritized_note(GameManager.SHIT_RATING_WINDOW):
-					#if SettingsManager.get_value(SettingsManager.SEC_PREFERENCES, "glow_notes") and !note.bad:
-						#note.modulate = Color(1.5, 1.5, 1.5)
-		
-		if auto_play:
-			if time_difference <= delta:
-				if !ignored_note_types.has(note.note_type):
-					if note != target_note:
-						note.hit = true
-						Signals.play_note_hit.emit(note, lane, 0, get_parent())
-					
-					if note.length > 0:
-						note.holding = true
-						var temp = note.length
-						var spb: float = get_relative_seconds_per_beat(note)
-						note.length = time_difference + (note.start_length * spb)
-						note.length /= spb
-						
-						if note.note.visible:
-							hold_cover_sprite.play_animation(&"start_" + strum_name + &"_cover")
-							hold_cover_sprite.visible = true
-						
-						note.note.visible = false
-						
-						Signals.play_note_holding.emit(note, lane, temp - max(0, note.length), get_parent())
-						state = STATE.GLOW
-					else:
-						reset_timer = GameManager.conductor.seconds_per_step
-						state = STATE.GLOW
-						
-						if can_splash:
-								hold_cover_sprite.play_animation(&"end_" + strum_name + &"_cover")
-						else:
-								hold_cover_sprite.visible = false
-						
-						note_list.erase(note)
-						note.queue_free()
-					continue
-		
-		var relative_time: float = time_difference - offset + (note.start_length * GameManager.conductor.seconds_per_beat)
+	#if !enemy_slot:
+	#if note == get_prioritized_note(GameManager.SHIT_RATING_WINDOW):
+		#if SettingsManager.get_value(SettingsManager.SEC_PREFERENCES, "glow_notes") and !note.bad:
+			#note.modulate = Color(1.5, 1.5, 1.5)
+	target_note = get_prioritized_note(GameManager.SHIT_RATING_WINDOW)
+	
+	if target_note:
+		var relative_time: float = target_note.time_difference - offset + (target_note.start_length * GameManager.conductor.seconds_per_beat)
 		var hit_window: float = GameManager.SHIT_RATING_WINDOW
-		
 		if relative_time <= -hit_window and coyote_timer <= 0:
-			note_list.erase(note)
-			Signals.play_note_miss.emit(note, lane, get_parent())
-			note.queue_free()
-		
+			note_list.erase(target_note)
+			Signals.play_note_miss.emit(target_note, lane, get_parent())
+			target_note.queue_free()
+	
 	# Inputs
 	if Input.is_action_just_pressed(input):
 		if can_press:
-			var note = get_prioritized_note(GameManager.SHIT_RATING_WINDOW)
-			if note:
-				if note.can_press:
-					if note.length <= 0:
-						state = STATE.GLOW
-						coyote_timer = 0
-						
-						note.hit = true
-						note_list.erase(note)
-						note.queue_free()
-						pressing = false
-						var time_difference: float = (note.time - offset) - (GameManager.song_position)
-						Signals.play_note_hit.emit(note, lane, time_difference, get_parent())
-					else:
-						var time_difference = (note.time - offset) - (GameManager.song_position)
-						if note != target_note:
-							note.hit = true
-							Signals.play_note_hit.emit(note, lane, time_difference, get_parent())
-						
-						coyote_timer = 0
-						
-						if !pressing:
-							hold_cover_sprite.play_animation(&"start_" + strum_name + &"_cover")
-							hold_cover_sprite.visible = true
-						
-						pressing = true
-						note.holding = true
-						target_note = note
+			if target_note:
+				state = STATE.GLOW
+				coyote_timer = 0
+				target_note.hit = true
+				var hit_time: float = (target_note.time - offset) - (GameManager.song_position)
+				Signals.play_note_hit.emit(target_note, lane, hit_time, get_parent())
+				
+				if target_note.length <= 0:
+					note_list.erase(target_note)
+					target_note.queue_free()
+					pressing = false
 				else:
-					if !SettingsManager.get_value(SettingsManager.SEC_GAMEPLAY, "ghost_tapping"):
-						Signals.play_note_miss.emit(null, lane, get_parent())
+					if !pressing:
+						hold_cover_sprite.play_animation(&"start_" + strum_name + &"_cover")
+						hold_cover_sprite.visible = true
+					
+					pressing = true
+					target_note.holding = true
 			else:
 				if !SettingsManager.get_value(SettingsManager.SEC_GAMEPLAY, "ghost_tapping"):
 					Signals.play_note_miss.emit(null, lane, get_parent())
-		
+	
 	if Input.is_action_pressed(input):
-		if can_press:
-			if pressing:
-				var note = get_prioritized_note(GameManager.SHIT_RATING_WINDOW)
-				if note:
-					if note.can_press:
-						if note.length > 0:
-							state = STATE.GLOW
-							note.position.y = 0
-							var temp = note.length
-							var spb: float = get_relative_seconds_per_beat(note)
-							note.length = ((note.time - offset) + (note.start_length * spb)) - GameManager.song_position
-							note.length /= spb
-							note.note.visible = false
-							Signals.play_note_holding.emit(note, lane, temp - max(0, note.length), get_parent())
-							
-							if !pressing:
-								hold_cover_sprite.play_animation(&"start_" + strum_name + &"_cover")
-								hold_cover_sprite.visible = true
-							
-							pressing = true
-							
-							if note.length <= 0:
-								pressing = false
-								if can_splash:
-									hold_cover_sprite.play_animation(&"end_" + strum_name + &"_cover")
-								else:
-									hold_cover_sprite.visible = false
-								
-								note_list.remove_at(0)
-								note.queue_free()
+		if can_press and pressing:
+			if target_note:
+				if target_note.length > 0:
+					state = STATE.GLOW
+					target_note.position.y = 0
+					var temp = target_note.length
+					var spb: float = get_relative_seconds_per_beat(target_note)
+					target_note.length = ((target_note.time - offset) + (target_note.start_length * spb)) - GameManager.song_position
+					target_note.length /= spb
+					target_note.note.visible = false
+					Signals.play_note_holding.emit(target_note, lane, temp - max(0, target_note.length), get_parent())
+					
+					if target_note.length <= 0:
+						pressing = false
+						if can_splash:
+							hold_cover_sprite.play_animation(&"end_" + strum_name + &"_cover")
+						else:
+							hold_cover_sprite.visible = false
+						
+						note_list.erase(target_note)
+						target_note.queue_free()
 			elif state != STATE.GLOW:
 				state = STATE.PRESSED
 	
@@ -315,16 +250,30 @@ func get_prioritized_note(hit_window: float) -> Variant:
 		return null
 	
 	var target = null
-	for note in note_list:
+	for note in note_list: 
 		if note.hit:
 			continue
+		
+		if note.time_difference > hit_window:
+			break
 		
 		target = note
 		
 		if !ignored_note_types.has(note.note_type):
 			return note
-		
-		if note.time_difference > hit_window:
-			break
 	
 	return target
+
+
+func set_scroll_speed(s: float):
+	scroll_speed = s
+	
+	for note in note_list:
+		note.scroll_speed = s
+
+
+func set_scroll(s: float):
+	scroll = s
+	
+	for note in note_list:
+		note.scroll = s

--- a/noah/game/strumlines/strum.gd
+++ b/noah/game/strumlines/strum.gd
@@ -67,64 +67,34 @@ func _process(delta) -> void:
 			Signals.play_note_miss.emit(target_note, lane, get_parent())
 			target_note.queue_free()
 	
-	# Inputs
-	if Input.is_action_just_pressed(input):
-		if can_press:
-			if target_note:
-				state = STATE.GLOW
-				coyote_timer = 0
-				var hit_time: float = (target_note.time - offset) - (GameManager.song_position)
-				Signals.play_note_hit.emit(target_note, lane, hit_time, get_parent())
+	if auto_play:
+		if target_note:
+			if target_note.time_difference <= delta:
+				reset_timer = GameManager.conductor.seconds_per_step
 				
-				if target_note.length <= 0:
-					target_note.hit = true
-					pressing = false
-					var hit_rating: GameManager.HIT_RATING = NoahStats.get_hit_rating(hit_time)
-					if hit_rating == GameManager.HIT_RATING.BAD or hit_rating == GameManager.HIT_RATING.SHIT:
-						target_note.hit = true
-						target_note.apply_miss_effect()
-					else:
-						note_list.erase(target_note)
-						target_note.queue_free()
+				if !pressing:
+					press_note()
 				else:
-					hold_cover_sprite.play_animation(&"start_" + strum_name + &"_cover")
-					hold_cover_sprite.visible = true
-					
-					pressing = true
-					target_note.holding = true
+					hold_note()
+	
+	# Inputs
+	if can_press:
+		if Input.is_action_just_pressed(input):
+			if target_note:
+				press_note()
 			else:
 				if !SettingsManager.get_value(SettingsManager.SEC_GAMEPLAY, "ghost_tapping"):
 					Signals.play_note_miss.emit(null, lane, get_parent())
-	
-	if Input.is_action_pressed(input):
-		if can_press:
+		
+		if Input.is_action_pressed(input):
 			if target_note:
-				if pressing:
-					if target_note.length > 0:
-						state = STATE.GLOW
-						target_note.position.y = 0
-						var temp = target_note.length
-						var spb: float = get_relative_seconds_per_beat(target_note)
-						target_note.length = ((target_note.time - offset) + (target_note.start_length * spb)) - GameManager.song_position
-						target_note.length /= spb
-						target_note.note.visible = false
-						Signals.play_note_holding.emit(target_note, lane, temp - max(0, target_note.length), get_parent())
-						
-						if target_note.length <= 0:
-							pressing = false
-							if can_splash:
-								hold_cover_sprite.play_animation(&"end_" + strum_name + &"_cover")
-							else:
-								hold_cover_sprite.visible = false
-							
-							note_list.erase(target_note)
-							target_note.queue_free()
+				if pressing and target_note.length > 0:
+					hold_note()
 			elif state != STATE.GLOW:
-				print("ok")
 				state = STATE.PRESSED
-	
-	if Input.is_action_just_released(input):
-		release_note()
+		
+		if Input.is_action_just_released(input):
+			release_note()
 	
 	if reset_timer > 0:
 		reset_timer -= delta
@@ -226,7 +196,52 @@ func create_splash(animation_name: StringName = strum_name + &"_splash"):
 			add_child(splash_instance)
 			splash_instance.get_node("OffsetSprite").play_animation(animation_name)
 
+## Calls when first pressing the input
+func press_note():
+	state = STATE.GLOW
+	coyote_timer = 0
+	var hit_time: float = (target_note.time - offset) - (GameManager.song_position) if !auto_play else 0.0
+	Signals.play_note_hit.emit(target_note, lane, hit_time, get_parent())
 
+	if target_note.length <= 0:
+		target_note.hit = true
+		pressing = false
+		var hit_rating: GameManager.HIT_RATING = NoahStats.get_hit_rating(hit_time)
+		if hit_rating == GameManager.HIT_RATING.BAD or hit_rating == GameManager.HIT_RATING.SHIT:
+			target_note.hit = true
+			target_note.apply_miss_effect()
+		else:
+			note_list.erase(target_note)
+			target_note.queue_free()
+	else:
+		hold_cover_sprite.play_animation(&"start_" + strum_name + &"_cover")
+		hold_cover_sprite.visible = true
+		
+		pressing = true
+		target_note.holding = true
+
+## Calls when holding the input
+func hold_note():
+	state = STATE.GLOW
+	target_note.position.y = 0
+	var temp = target_note.length
+	var spb: float = get_relative_seconds_per_beat(target_note)
+	target_note.length = ((target_note.time - offset) + (target_note.start_length * spb)) - GameManager.song_position
+	target_note.length /= spb
+	target_note.note.visible = false
+	Signals.play_note_holding.emit(target_note, lane, temp - max(0, target_note.length), get_parent())
+
+	if target_note.length <= 0:
+		pressing = false
+		if can_splash:
+			hold_cover_sprite.play_animation(&"end_" + strum_name + &"_cover")
+		else:
+			hold_cover_sprite.visible = false
+		
+		note_list.erase(target_note)
+		target_note.queue_free()
+
+## Calls when releasing the input
 func release_note():
 	if can_press:
 		if pressing:
@@ -263,10 +278,10 @@ func get_prioritized_note(hit_window: float) -> BasicNote:
 		if note.time_difference > hit_window:
 			break
 		
-		target = note
-		
 		if !ignored_note_types.has(note.note_type):
 			return note
+		else:
+			target = note
 	
 	return target
 

--- a/noah/game/strumlines/strum.gd
+++ b/noah/game/strumlines/strum.gd
@@ -53,15 +53,14 @@ func _ready() -> void:
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta) -> void:
-	#if !enemy_slot:
-	#if note == get_prioritized_note(GameManager.SHIT_RATING_WINDOW):
-		#if SettingsManager.get_value(SettingsManager.SEC_PREFERENCES, "glow_notes") and !note.bad:
-			#note.modulate = Color(1.5, 1.5, 1.5)
-	target_note = get_prioritized_note(GameManager.SHIT_RATING_WINDOW)
+	target_note = get_prioritized_note(NoahStats.SHIT_RATING_WINDOW)
 	
 	if target_note:
+		if SettingsManager.get_value(SettingsManager.SEC_PREFERENCES, "glow_notes") and !ignored_note_types.has(target_note.note_type):
+			target_note.modulate = Color(1.5, 1.5, 1.5)
+		
 		var relative_time: float = target_note.time_difference - offset + (target_note.start_length * GameManager.conductor.seconds_per_beat)
-		var hit_window: float = GameManager.SHIT_RATING_WINDOW
+		var hit_window: float = NoahStats.SHIT_RATING_WINDOW
 		if relative_time <= -hit_window and coyote_timer <= 0:
 			note_list.erase(target_note)
 			Signals.play_note_miss.emit(target_note, lane, get_parent())
@@ -206,8 +205,8 @@ func press_note():
 	if target_note.length <= 0:
 		target_note.hit = true
 		pressing = false
-		var hit_rating: GameManager.HIT_RATING = NoahStats.get_hit_rating(hit_time)
-		if hit_rating == GameManager.HIT_RATING.BAD or hit_rating == GameManager.HIT_RATING.SHIT:
+		var hit_rating: NoahStats.HIT_RATING = NoahStats.get_hit_rating(hit_time)
+		if hit_rating == NoahStats.HIT_RATING.BAD or hit_rating == NoahStats.HIT_RATING.SHIT:
 			target_note.hit = true
 			target_note.apply_miss_effect()
 		else:

--- a/noah/managers/game_manager.gd
+++ b/noah/managers/game_manager.gd
@@ -1,21 +1,9 @@
 extends Node
 
 # These are explanatory.
-const SICK_RATING_WINDOW: float = 0.045
-const GOOD_RATING_WINDOW: float = 0.09
-const BAD_RATING_WINDOW: float = 0.135
-const SHIT_RATING_WINDOW: float = 0.16
 const GOOD_COMBO_FREQUENCY: int = 50
 const GREAT_COMBO_FREQUENCY: int = 200
 const HOLD_NOTE_LENIENCY: float = 1 / 3.0
-
-# These are explanatory.
-const GOLD_RANK_REQ: float = 2.0
-const PERFECT_RANK_REQ: float = 1.0
-const EXCELLENT_RANK_REQ: float = 0.90
-const GREAT_RANK_REQ: float = 0.80
-const GOOD_RANK_REQ: float = 0.60
-const LOSS_RANK_REQ: float = 0.00
 
 ## The last remembered song scene assigned by [PlayState]. useful for needing to return to a song after exiting the scene.
 var song_scene: String = ''
@@ -31,20 +19,6 @@ enum PLAY_MODE {
 	FREEPLAY,
 	## Returns to the editor after play.
 	CHARTING,
-}
-
-## Rating of the hit time of a note.
-enum HIT_RATING {
-	## Given when a note isn't hit within any window
-	MISS = -1,
-	## Given when a note is hit within the [constant SICK_RATING_WINDOW] window.
-	SICK,
-	## Given when a note is hit within the [constant GOOD_RATING_WINDOW] window.
-	GOOD,
-	## Given when a note is hit within the [constant BAD_RATING_WINDOW] window.
-	BAD,
-	## Given when a note is hit within the [constant SHIT_RATING_WINDOW] window.
-	SHIT
 }
 
 ## The previous played song's remembered stats. Can be used for things such as a result screen.

--- a/noah/managers/game_manager.gd
+++ b/noah/managers/game_manager.gd
@@ -33,6 +33,20 @@ enum PLAY_MODE {
 	CHARTING,
 }
 
+## Rating of the hit time of a note.
+enum HIT_RATING {
+	## Given when a note isn't hit within any window
+	MISS = -1,
+	## Given when a note is hit within the [constant SICK_RATING_WINDOW] window.
+	SICK,
+	## Given when a note is hit within the [constant GOOD_RATING_WINDOW] window.
+	GOOD,
+	## Given when a note is hit within the [constant BAD_RATING_WINDOW] window.
+	BAD,
+	## Given when a note is hit within the [constant SHIT_RATING_WINDOW] window.
+	SHIT
+}
+
 ## The previous played song's remembered stats. Can be used for things such as a result screen.
 ## [br][br][color=khaki]NOTE[/color]: these are only set after a song is finished and not in real time.
 var last_song_stats: NoahStats = NoahStats.new()

--- a/noah/resources/noah_stats.gd
+++ b/noah/resources/noah_stats.gd
@@ -126,20 +126,20 @@ static func get_rank_from_grade(_grade: float) -> String:
 	return "?"
 
 ## Returns the rating of the absolute value of the relative time a note was hit.
-static func get_hit_rating(hit_time: float) -> String:
+static func get_hit_rating(hit_time: float) -> GameManager.HIT_RATING:
 	hit_time = abs(hit_time)
 	var ratings: Array = [
-		[hit_time <= GameManager.SICK_RATING_WINDOW, "sick"],
-		[hit_time <= GameManager.GOOD_RATING_WINDOW, "good"],
-		[hit_time <= GameManager.BAD_RATING_WINDOW, "bad"],
-		[hit_time <= GameManager.SHIT_RATING_WINDOW, "shit"]
+		[hit_time <= GameManager.SICK_RATING_WINDOW, GameManager.HIT_RATING.SICK],
+		[hit_time <= GameManager.GOOD_RATING_WINDOW, GameManager.HIT_RATING.GOOD],
+		[hit_time <= GameManager.BAD_RATING_WINDOW, GameManager.HIT_RATING.BAD],
+		[hit_time <= GameManager.SHIT_RATING_WINDOW, GameManager.HIT_RATING.SHIT]
 	]
 	
 	for condition in ratings:
 		if condition[0]:
 			return condition[1]
 	
-	return "miss"
+	return GameManager.HIT_RATING.MISS
 
 func _to_string() -> String:
 	var buffer: PackedStringArray = PackedStringArray()

--- a/noah/resources/noah_stats.gd
+++ b/noah/resources/noah_stats.gd
@@ -2,6 +2,15 @@ extends Resource
 class_name NoahStats
 ## Handles values defining the players gameplay.
 
+## Hit window for the best hit rating
+const SICK_RATING_WINDOW: float = 0.045
+## Hit window for a good hit rating
+const GOOD_RATING_WINDOW: float = 0.09
+## Hit window for a bad hit rating
+const BAD_RATING_WINDOW: float = 0.135
+## Hit window for the worst hit rating
+const SHIT_RATING_WINDOW: float = 0.16
+
 ## The required minimum [member grade] must reach to provide [member GOLD_RANK_NAME]
 const GOLD_RANK_REQ: float = 2.0
 ## The required minimum [member grade] must reach to provide [member PERFECT_RANK_REQ]
@@ -14,6 +23,20 @@ const GREAT_RANK_REQ: float = 0.80
 const GOOD_RANK_REQ: float = 0.60
 ## The required minimum [member grade] must reach to provide [member LOSS_RANK_REQ]
 const LOSS_RANK_REQ: float = 0.00
+
+## Rating of the hit time of a note.
+enum HIT_RATING {
+	## Given when a note isn't hit within any window
+	MISS = -1,
+	## Given when a note is hit within the [constant SICK_RATING_WINDOW] window.
+	SICK,
+	## Given when a note is hit within the [constant GOOD_RATING_WINDOW] window.
+	GOOD,
+	## Given when a note is hit within the [constant BAD_RATING_WINDOW] window.
+	BAD,
+	## Given when a note is hit within the [constant SHIT_RATING_WINDOW] window.
+	SHIT
+}
 
 ## The accumulated score reached by the player.
 var score: float = 0
@@ -126,20 +149,20 @@ static func get_rank_from_grade(_grade: float) -> String:
 	return "?"
 
 ## Returns the rating of the absolute value of the relative time a note was hit.
-static func get_hit_rating(hit_time: float) -> GameManager.HIT_RATING:
+static func get_hit_rating(hit_time: float) -> HIT_RATING:
 	hit_time = abs(hit_time)
 	var ratings: Array = [
-		[hit_time <= GameManager.SICK_RATING_WINDOW, GameManager.HIT_RATING.SICK],
-		[hit_time <= GameManager.GOOD_RATING_WINDOW, GameManager.HIT_RATING.GOOD],
-		[hit_time <= GameManager.BAD_RATING_WINDOW, GameManager.HIT_RATING.BAD],
-		[hit_time <= GameManager.SHIT_RATING_WINDOW, GameManager.HIT_RATING.SHIT]
+		[hit_time <= SICK_RATING_WINDOW, HIT_RATING.SICK],
+		[hit_time <= GOOD_RATING_WINDOW, HIT_RATING.GOOD],
+		[hit_time <= BAD_RATING_WINDOW, HIT_RATING.BAD],
+		[hit_time <= SHIT_RATING_WINDOW, HIT_RATING.SHIT]
 	]
 	
 	for condition in ratings:
 		if condition[0]:
 			return condition[1]
 	
-	return GameManager.HIT_RATING.MISS
+	return HIT_RATING.MISS
 
 func _to_string() -> String:
 	var buffer: PackedStringArray = PackedStringArray()


### PR DESCRIPTION
- Adds a new note priority system which puts ignored notes in lower priority in the case of multiple notes being within the general hit window
- Cleans up `strum.gd` for an easier, readable experience
- Adds a new "miss" effect for notes on a bad hit or failed sustain note recovery
- Changes `NoahStats.get_hit_rating()` to return an enum instead of a String.
- Moved stat related enums from `GameManager` to `NoahStats`